### PR TITLE
Syntax sugar to makeOneShotStateProperty when Input is Void

### DIFF
--- a/RetryIt/Components/SuperSecuredScreen.swift
+++ b/RetryIt/Components/SuperSecuredScreen.swift
@@ -37,7 +37,7 @@ final class SuperSecuredScreen {
 
         let retryableAction = RetryableAction(original: action)
 
-        let state = retryableAction.makeOneShotStateProperty(input: ())
+        let state = retryableAction.makeOneShotStateProperty()
         self.alert = state.producer
             .map { $0.alert }
             .ignoreNil()

--- a/RetryIt/Retryable/Retryable.swift
+++ b/RetryIt/Retryable/Retryable.swift
@@ -183,3 +183,10 @@ extension RetryableAction {
         ).map { $0 ?? .loading }
     }
 }
+
+extension RetryableAction where Input == Void {
+
+    func makeOneShotStateProperty() -> Property<LoadingState<Output, Error>> {
+        return makeOneShotStateProperty(input: ())
+    }
+}


### PR DESCRIPTION
Hi, Sergey. Thanks for the meetup.
That's a simple syntax sugar when Input is Void, so we can call makeOneShotStateProperty() instead of makeOneShotStateProperty(input: ()).
Hope you'll find this helpfull. 😉